### PR TITLE
feat(preference): 향수 선호여부 등록 기능 추가

### DIFF
--- a/src/api/preference.js
+++ b/src/api/preference.js
@@ -1,0 +1,9 @@
+import { http } from "./http";
+
+export function recordPreference(perfumeId, payload) {
+  return http.post(`/preferences/${perfumeId}`, payload);
+}
+
+export function checkLiked(perfumeId) {
+  return http.get(`/preferences/${perfumeId}/liked`);
+}

--- a/src/styles/pages/PerfumeDetailPage.css
+++ b/src/styles/pages/PerfumeDetailPage.css
@@ -189,3 +189,55 @@
 .rating-distribution .dist-line {
   margin-top: 4px;
 }
+
+.preference-form {
+  margin-top: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.preference-form .status-radio {
+  display: flex;
+  gap: 12px;
+}
+
+.preference-form .status-radio label {
+  cursor: pointer;
+  font-weight: 500;
+}
+
+.preference-form .date-picker {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.preference-form input[type="date"] {
+  padding: 6px 8px;
+  border-radius: 6px;
+  border: 1px solid #ccc;
+}
+
+.preference-form .form-actions {
+  display: flex;
+  gap: 8px;
+}
+
+.preference-form button {
+  padding: 8px 12px;
+  border-radius: 6px;
+  border: none;
+  cursor: pointer;
+  font-weight: 500;
+}
+
+.preference-form button[type="submit"] {
+  background-color: #222;
+  color: #fff;
+}
+
+.preference-form button[type="button"] {
+  background-color: #eee;
+  color: #222;
+}


### PR DESCRIPTION
## 📄 Summary
>향수 상세페이지에 선호도(선호/비선호 + 사용일) 등록 UI 추가 및 API 연동
>선호 등록은 버튼 클릭 시 라디오(선호/비선호) + 날짜 선택 노출, 사용자가 등록 버튼 누를 때만 서버 요청 발생

## 🙋🏻 More
>
