### PR TITLE
fix(search): 향수 졍렬(기본순/인기순/최신순/평점순/선호순) 수정

### DIFF
--- a/src/api/preference.js
+++ b/src/api/preference.js
@@ -1,0 +1,13 @@
+import { http } from "./http";
+
+export function recordPreference(perfumeId, payload) {
+  return http.post(`/preferences/${perfumeId}`, payload);
+}
+
+export function checkLiked(perfumeId) {
+  return http.get(`/preferences/${perfumeId}/liked`);
+}
+
+export function fetchPreferredPerfumes() {
+  return http.get("/preferences");
+}


### PR DESCRIPTION
📄 Summary
>정렬 옵션 기본순/최신순/평점순/선호순 추가
>‘기본순’ 데이터를 초기 로드 후 캐싱하여 인기순/최신순/평점순은 프론트 단에서 정렬하도록 처리
>선호순만 서버 호출로 데이터 갱신

🙋🏻 More
>