### PR TITLE
design: 마이페이지 및 계정 수정 화면 UI 개선 (정렬 옵션 및 컨테이너 크기 조정)

### DIFF
--- a/src/pages/SearchPage.js
+++ b/src/pages/SearchPage.js
@@ -170,12 +170,6 @@ export default function SearchPage() {
     const arr = [...origList];
     if (value === "POPULAR") {
       arr.sort((a, b) => (b.reviewCount || 0) - (a.reviewCount || 0));
-    } else if (value === "NEW") {
-      arr.sort((a, b) => {
-        const da = a.createdAt ? new Date(a.createdAt).getTime() : 0;
-        const db = b.createdAt ? new Date(b.createdAt).getTime() : 0;
-        return db - da;
-      });
     } else if (value === "RATING") {
       arr.sort((a, b) => (b.rating || 0) - (a.rating || 0));
     }
@@ -201,9 +195,8 @@ export default function SearchPage() {
           aria-label="정렬"
           onChange={(e) => handleSortChange(e.target.value)}
         >
-          <option value="DEFAULT">기본순</option>
+          <option value="DEFAULT">최신순</option>
           <option value="POPULAR">인기순</option>
-          <option value="NEW">최신순</option>
           <option value="RATING">평점순</option>
           <option value="PREFERRED">선호순</option>
         </select>

--- a/src/styles/pages/AccountEditPage.css
+++ b/src/styles/pages/AccountEditPage.css
@@ -1,5 +1,5 @@
 .container {
-  max-width: 720px;
+  max-width: 1200px;
   margin: 0 auto;
   padding: 24px;
 }

--- a/src/styles/pages/MyPage.css
+++ b/src/styles/pages/MyPage.css
@@ -1,5 +1,5 @@
 .container {
-  max-width: 1400px;
+  max-width: 1200px;
   margin: 0 auto;
   padding: 24px;
 }


### PR DESCRIPTION
## 📄 Summary
>마이페이지와 계정 수정 페이지의 컨테이너 최대 너비를 1200px로 수정했습니다.
정렬 옵션에서 ‘기본순’을 ‘최신순’으로 변경하습니다.

## 🙋🏻 More
>
